### PR TITLE
Fix for floating number not able to be parsed (Godot)

### DIFF
--- a/src/Lua/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Lua/CodeAnalysis/Syntax/Parser.cs
@@ -1010,7 +1010,7 @@ public ref struct Parser
         }
         else
         {
-            return double.Parse(text.ToString(), CultureInfo.InvariantCulture);
+            return double.Parse(text, NumberStyles.Float, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/Lua/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Lua/CodeAnalysis/Syntax/Parser.cs
@@ -1010,7 +1010,7 @@ public ref struct Parser
         }
         else
         {
-            return double.Parse(text);
+            return double.Parse(text.ToString(), CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/Lua/LuaValue.cs
+++ b/src/Lua/LuaValue.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Lua.Internal;
@@ -120,7 +121,7 @@ public readonly struct LuaValue : IEquatable<LuaValue>
                     }
                     else
                     {
-                        var tryResult = double.TryParse(str, out var d);
+                        var tryResult = double.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out var d);
                         result = tryResult ? Unsafe.As<double, T>(ref d) : default!;
                         return tryResult;
                     }

--- a/src/Lua/Standard/BasicLibrary.cs
+++ b/src/Lua/Standard/BasicLibrary.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Lua.CodeAnalysis.Compilation;
 using Lua.Internal;
 using Lua.Runtime;
@@ -445,7 +446,7 @@ public sealed class BasicLibrary
             }
             else if (toBase == 10)
             {
-                if (double.TryParse(str, out var result))
+                if (double.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
                 {
                     value = result;
                 }


### PR DESCRIPTION
Hello, I started using Lua-CSharp in Godot for my game to implement modding and map making scripts.
While testing my script I realized that in Godot when using floating number the parser would make the script crash and while searching the error I come up with this little change, which fixes the crashes.

Small exemple of a script in my test scene :
https://github.com/user-attachments/assets/34f8c20b-d729-450d-b18f-685081274d3a

(Hope it can be useful ^^)