### PR TITLE
Fix LuaObject bugs

### DIFF
--- a/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
+++ b/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
@@ -361,7 +361,14 @@ partial class LuaObjectGenerator
 
             foreach (var parameter in methodMetadata.Symbol.Parameters)
             {
-                builder.AppendLine($"var arg{index} = context.GetArgument<{parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({index});");
+                if (SymbolEqualityComparer.Default.Equals(parameter.Type, references.LuaValue))
+                {
+                    builder.AppendLine($"var arg{index} = context.GetArgument({index});");
+                }
+                else
+                {
+                    builder.AppendLine($"var arg{index} = context.GetArgument<{parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({index});");
+                }
                 index++;
             }
 

--- a/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
+++ b/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Lua.SourceGenerator;
 
@@ -361,13 +362,31 @@ partial class LuaObjectGenerator
 
             foreach (var parameter in methodMetadata.Symbol.Parameters)
             {
-                if (SymbolEqualityComparer.Default.Equals(parameter.Type, references.LuaValue))
+                var isParameterLuaValue = SymbolEqualityComparer.Default.Equals(parameter.Type, references.LuaValue);
+
+                if (parameter.HasExplicitDefaultValue)
                 {
-                    builder.AppendLine($"var arg{index} = context.GetArgument({index});");
+                    var syntax = (ParameterSyntax)parameter.DeclaringSyntaxReferences[0].GetSyntax();
+
+                    if (isParameterLuaValue)
+                    {
+                        builder.AppendLine($"var arg{index} = context.HasArgument({index}) ? context.GetArgument({index}) : {syntax.Default!.Value.ToFullString()};");
+                    }
+                    else
+                    {
+                        builder.AppendLine($"var arg{index} = context.HasArgument({index}) ?  context.GetArgument<{parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({index}) : {syntax.Default!.Value.ToFullString()};");
+                    }
                 }
                 else
                 {
-                    builder.AppendLine($"var arg{index} = context.GetArgument<{parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({index});");
+                    if (isParameterLuaValue)
+                    {
+                        builder.AppendLine($"var arg{index} = context.GetArgument({index});");
+                    }
+                    else
+                    {
+                        builder.AppendLine($"var arg{index} = context.GetArgument<{parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({index});");
+                    }
                 }
                 index++;
             }
@@ -405,7 +424,7 @@ partial class LuaObjectGenerator
                 {
                     builder.AppendLine("buffer.Span[0] = new global::Lua.LuaValue(result);");
                 }
-                
+
                 builder.AppendLine($"return {(methodMetadata.IsAsync ? "1" : "new(1)")};");
             }
             else

--- a/src/Lua/LuaValue.cs
+++ b/src/Lua/LuaValue.cs
@@ -46,6 +46,18 @@ public readonly struct LuaValue : IEquatable<LuaValue>
                     result = Unsafe.As<double, T>(ref v);
                     return true;
                 }
+                else if (t == typeof(int))
+                {
+                    var v = (int)value;
+                    result = Unsafe.As<int, T>(ref v);
+                    return true;
+                }
+                else if (t == typeof(long))
+                {
+                    var v = (long)value;
+                    result = Unsafe.As<long, T>(ref v);
+                    return true;
+                }
                 else if (t == typeof(object))
                 {
                     result = (T)(object)value;


### PR DESCRIPTION
This PR includes fixes for #50 and #51. It fixes the issue where a runtime exception occurs when the argument of a function with `[LuaMember]` is a `LuaValue`/`int`/`long`, and also makes it possible to omit arguments on the Lua side if the parameter has a default value.