### PR TITLE
Fix: metatable index/newindex with table

### DIFF
--- a/src/Lua/LuaTable.cs
+++ b/src/Lua/LuaTable.cs
@@ -109,6 +109,25 @@ public sealed class LuaTable
 
         return dictionary.TryGetValue(key, out value) && value.Type is not LuaValueType.Nil;
     }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ref LuaValue FindValue(LuaValue key)
+    {
+        if (key.Type is LuaValueType.Nil)
+        {
+            ThrowIndexIsNil();
+        }
+
+        if (TryGetInteger(key, out var index))
+        {
+            if (index > 0 && index <= array.Length)
+            {
+                return ref array[index - 1];
+            }
+        }
+
+        return ref dictionary.FindValue(key,out _);
+    }
 
     public bool ContainsKey(LuaValue key)
     {

--- a/src/Lua/LuaTable.cs
+++ b/src/Lua/LuaTable.cs
@@ -109,7 +109,7 @@ public sealed class LuaTable
 
         return dictionary.TryGetValue(key, out value) && value.Type is not LuaValueType.Nil;
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ref LuaValue FindValue(LuaValue key)
     {
@@ -126,7 +126,7 @@ public sealed class LuaTable
             }
         }
 
-        return ref dictionary.FindValue(key,out _);
+        return ref dictionary.FindValue(key, out _);
     }
 
     public bool ContainsKey(LuaValue key)
@@ -213,7 +213,7 @@ public sealed class LuaTable
         }
         else
         {
-            if(dictionary.TryGetNext(key, out pair))
+            if (dictionary.TryGetNext(key, out pair))
             {
                 return true;
             }

--- a/src/Lua/Runtime/Closure.cs
+++ b/src/Lua/Runtime/Closure.cs
@@ -32,6 +32,12 @@ public sealed class Closure : LuaFunction
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ref readonly LuaValue GetUpValueRef(int index)
+    {
+        return ref upValues[index].GetValueRef();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void SetUpValue(int index, LuaValue value)
     {
         upValues[index].SetValue(value);
@@ -43,17 +49,17 @@ public sealed class Closure : LuaFunction
         {
             return state.GetOrAddUpValue(thread, thread.GetCallStackFrames()[^1].Base + description.Index);
         }
-        
+
         if (description.Index == -1) // -1 is global environment
         {
             return envUpValue;
         }
-        
+
         if (thread.GetCallStackFrames()[^1].Function is Closure parentClosure)
         {
-             return parentClosure.UpValues[description.Index];
+            return parentClosure.UpValues[description.Index];
         }
-        
+
         throw new Exception();
     }
 }

--- a/src/Lua/Runtime/LuaVirtualMachine.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.cs
@@ -424,8 +424,8 @@ public static partial class LuaVirtualMachine
                         vc = ref RKC(ref stackHead, ref constHead, instruction);
                         table = Unsafe.Add(ref stackHead, instruction.UIntB);
 
-
-                        if (GetTableValueSlowPath(table, vc, ref context, out resultValue, out doRestart))
+                        doRestart = false;
+                        if ((table.TryReadTable(out luaTable) && luaTable.TryGetValue(vc, out resultValue)) || GetTableValueSlowPath(table, vc, ref context, out resultValue, out doRestart))
                         {
                             if (doRestart) goto Restart;
                             Unsafe.Add(ref stackHead, iA) = resultValue;

--- a/src/Lua/Runtime/LuaVirtualMachine.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.cs
@@ -314,7 +314,7 @@ public static partial class LuaVirtualMachine
                         var table = context.Closure.GetUpValue(instruction.B);
 
                         var doRestart = false;
-                        if (table.TryReadTable(out var luaTable) && luaTable.TryGetValue(vc, out var resultValue) || TryGetValueWithSync(table, vc, ref context, out resultValue, out doRestart))
+                        if (table.TryReadTable(out var luaTable) && luaTable.TryGetValue(vc, out var resultValue) || GetTableValueSlowPath(table, vc, ref context, out resultValue, out doRestart))
                         {
                             if (doRestart) goto Restart;
                             stack.GetWithNotifyTop(instruction.A + frameBase) = resultValue;
@@ -329,7 +329,7 @@ public static partial class LuaVirtualMachine
                         ref readonly var vb = ref Unsafe.Add(ref stackHead, instruction.UIntB);
                         vc = ref RKC(ref stackHead, ref constHead, instruction);
                         doRestart = false;
-                        if (vb.TryReadTable(out luaTable) && luaTable.TryGetValue(vc, out resultValue) || TryGetValueWithSync(vb, vc, ref context, out resultValue, out doRestart))
+                        if (vb.TryReadTable(out luaTable) && luaTable.TryGetValue(vc, out resultValue) || GetTableValueSlowPath(vb, vc, ref context, out resultValue, out doRestart))
                         {
                             if (doRestart) goto Restart;
                             stack.GetWithNotifyTop(instruction.A + frameBase) = resultValue;
@@ -365,7 +365,7 @@ public static partial class LuaVirtualMachine
                         }
 
                         vc = ref RKC(ref stackHead, ref constHead, instruction);
-                        if (TrySetMetaTableValueWithSync(table, vb, vc, ref context, out doRestart))
+                        if (SetTableValueSlowPath(table, vb, vc, ref context, out doRestart))
                         {
                             if (doRestart) goto Restart;
                             continue;
@@ -405,7 +405,7 @@ public static partial class LuaVirtualMachine
                         }
 
                         vc = ref RKC(ref stackHead, ref constHead, instruction);
-                        if (TrySetMetaTableValueWithSync(table, vb, vc, ref context, out doRestart))
+                        if (SetTableValueSlowPath(table, vb, vc, ref context, out doRestart))
                         {
                             if (doRestart) goto Restart;
                             continue;
@@ -425,7 +425,7 @@ public static partial class LuaVirtualMachine
                         table = Unsafe.Add(ref stackHead, instruction.UIntB);
 
 
-                        if (TryGetValueWithSync(table, vc, ref context, out resultValue, out doRestart))
+                        if (GetTableValueSlowPath(table, vc, ref context, out resultValue, out doRestart))
                         {
                             if (doRestart) goto Restart;
                             Unsafe.Add(ref stackHead, iA) = resultValue;
@@ -1309,7 +1309,7 @@ public static partial class LuaVirtualMachine
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static bool TryGetValueWithSync(LuaValue table, LuaValue key, ref VirtualMachineExecutionContext context, out LuaValue value, out bool doRestart)
+    static bool GetTableValueSlowPath(LuaValue table, LuaValue key, ref VirtualMachineExecutionContext context, out LuaValue value, out bool doRestart)
     {
         var targetTable = table;
         const int MAX_LOOP = 100;
@@ -1389,7 +1389,7 @@ public static partial class LuaVirtualMachine
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static bool TrySetMetaTableValueWithSync(LuaValue table, LuaValue key, LuaValue value,
+    static bool SetTableValueSlowPath(LuaValue table, LuaValue key, LuaValue value,
         ref VirtualMachineExecutionContext context, out bool doRestart)
     {
         var targetTable = table;

--- a/src/Lua/Runtime/LuaVirtualMachine.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.cs
@@ -368,7 +368,6 @@ public static partial class LuaVirtualMachine
                         if (TrySetMetaTableValueWithSync(table, vb, vc, ref context, out doRestart))
                         {
                             if (doRestart) goto Restart;
-
                             continue;
                         }
 
@@ -434,20 +433,6 @@ public static partial class LuaVirtualMachine
                             stack.NotifyTop(iA + frameBase + 2);
                             continue;
                         }
-                        // if (table.TryReadTable(out luaTable) && luaTable.TryGetValue(vc, out resultValue))
-                        // {
-                        //     Unsafe.Add(ref stackHead, iA) = resultValue;
-                        //     Unsafe.Add(ref stackHead, iA + 1) = table;
-                        //     stack.NotifyTop(iA + frameBase + 2);
-                        //     continue;
-                        // }
-                        //
-                        //
-                        // if (TryGetMetaTableValue(table, vc, ref context, out doRestart))
-                        // {
-                        //     if (doRestart) goto Restart;
-                        //     continue;
-                        // }
 
                         postOperation = PostOperationType.Self;
                         return true;

--- a/src/Lua/Runtime/LuaVirtualMachine.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.cs
@@ -1404,7 +1404,7 @@ public static partial class LuaVirtualMachine
                 skip = false;
                 if (!Unsafe.IsNullRef(ref valueRef) && valueRef.Type != LuaValueType.Nil)
                 {
-                    luaTable[key] = value;
+                    valueRef = value;
                     return true;
                 }
 

--- a/src/Lua/Runtime/LuaVirtualMachine.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.cs
@@ -92,20 +92,19 @@ public static partial class LuaVirtualMachine
             switch (opCode)
             {
                 case OpCode.Call:
-                {
-                    var c = callInstruction.C;
-                    if (c != 0)
                     {
-                        targetCount = c - 1;
-                    }
+                        var c = callInstruction.C;
+                        if (c != 0)
+                        {
+                            targetCount = c - 1;
+                        }
 
-                    break;
-                }
+                        break;
+                    }
                 case OpCode.TForCall:
                     target += 3;
                     targetCount = callInstruction.C;
                     break;
-
                 case OpCode.Self:
                     Stack.Get(target) = result.Length == 0 ? LuaValue.Nil : result[0];
                     Thread.PopCallStackFrameUnsafe(target + 2);
@@ -266,7 +265,7 @@ public static partial class LuaVirtualMachine
 
         try
         {
-            // This is a label to restart the execution when new function is called or restarted
+        // This is a label to restart the execution when new function is called or restarted
         Restart:
             ref var instructionsHead = ref context.Chunk.Instructions[0];
             var frameBase = context.FrameBase;
@@ -337,7 +336,7 @@ public static partial class LuaVirtualMachine
                         }
 
                         var table = context.Closure.GetUpValue(instruction.A);
-                        
+
                         if (table.TryReadTable(out luaTable))
                         {
                             ref var valueRef = ref luaTable.FindValue(vb);

--- a/src/Lua/Runtime/UpValue.cs
+++ b/src/Lua/Runtime/UpValue.cs
@@ -45,6 +45,19 @@ public sealed class UpValue
             return Thread!.Stack.Get(RegisterIndex);
         }
     }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ref readonly LuaValue GetValueRef()
+    {
+        if (IsClosed)
+        {
+            return ref value;
+        }
+        else
+        {
+            return ref Thread!.Stack.Get(RegisterIndex);
+        }
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetValue(LuaValue value)

--- a/tests/Lua.Tests/MetatableTests.cs
+++ b/tests/Lua.Tests/MetatableTests.cs
@@ -46,4 +46,44 @@ return a + b
             Assert.That(table[3].Read<double>(), Is.EqualTo(9));
         });
     }
+
+    [Test]
+    public async Task Test_Metamethod_Index()
+    {
+        var source = @"
+metatable = {
+    __index = {x=1}
+}
+
+local a = {}
+setmetatable(a, metatable)
+assert(a.x == 1)
+metatable.__index= nil
+assert(a.x == nil)
+metatable.__index= function(a,b) return b end
+assert(a.x == 'x')
+";
+        await state.DoStringAsync(source);
+    }
+
+    [Test]
+    public async Task Test_Metamethod_NewIndex()
+    {
+        var source = @"
+metatable = {
+    __newindex = {}
+}
+
+local a = {}
+a.x = 1
+setmetatable(a, metatable)
+a.x = 2
+assert(a.x == 2)
+a.x = nil
+a.x = 2
+assert(a.x == nil)
+assert(metatable.__newindex.x == 2)
+";
+        await state.DoStringAsync(source);
+    }
 }


### PR DESCRIPTION
Lua must pass these tests.
```lua
metatable = {
    __index = {x=1}
}

local a = {}
setmetatable(a, metatable)
assert(a.x == 1)
metatable.__index= nil
assert(a.x == nil)
metatable.__index= function(a,b) return b end
assert(a.x == 'x')
```

```lua
metatable = {
    __newindex = {}
}

local a = {}
a.x = 1
setmetatable(a, metatable)
a.x = 2
assert(a.x == 2)
a.x = nil
a.x = 2
assert(a.x == nil)
assert(metatable.__newindex.x == 2)
```