### PR TITLE
Fix handling of `Read<int>()` and `GetArgument<int>()`

### DIFF
--- a/src/Lua/Exceptions.cs
+++ b/src/Lua/Exceptions.cs
@@ -100,11 +100,16 @@ public class LuaRuntimeException : LuaException
         throw new LuaRuntimeException(traceback, $"bad argument #{argumentId} to '{functionName}' ({expected} expected, got {actual})");
     }
 
+    public static void BadArgumentNumberIsNotInteger(Traceback traceback, int argumentId, string functionName)
+    {
+        throw new LuaRuntimeException(traceback, $"bad argument #{argumentId} to '{functionName}' (number has no integer representation)");
+    }
+
     public static void ThrowBadArgumentIfNumberIsNotInteger(LuaState state, string functionName, int argumentId, double value)
     {
         if (!MathEx.IsInteger(value))
         {
-            throw new LuaRuntimeException(state.GetTraceback(), $"bad argument #{argumentId} to '{functionName}' (number has no integer representation)");
+            BadArgumentNumberIsNotInteger(state.GetTraceback(), argumentId, functionName);
         }
     }
 

--- a/src/Lua/LuaFunctionExecutionContext.cs
+++ b/src/Lua/LuaFunctionExecutionContext.cs
@@ -46,13 +46,18 @@ public readonly record struct LuaFunctionExecutionContext
         var arg = Arguments[index];
         if (!arg.TryRead<T>(out var argValue))
         {
-            if (LuaValue.TryGetLuaValueType(typeof(T), out var type))
+            var t = typeof(T);
+            if ((t == typeof(int) || t == typeof(long)) && arg.TryReadNumber(out _))
+            {
+                LuaRuntimeException.BadArgumentNumberIsNotInteger(State.GetTraceback(), index + 1, Thread.GetCurrentFrame().Function.Name);
+            }
+            else if (LuaValue.TryGetLuaValueType(t, out var type))
             {
                 LuaRuntimeException.BadArgument(State.GetTraceback(), index + 1, Thread.GetCurrentFrame().Function.Name, type.ToString(), arg.Type.ToString());
             }
             else
             {
-                LuaRuntimeException.BadArgument(State.GetTraceback(), index + 1, Thread.GetCurrentFrame().Function.Name, typeof(T).Name, arg.Type.ToString());
+                LuaRuntimeException.BadArgument(State.GetTraceback(), index + 1, Thread.GetCurrentFrame().Function.Name, t.Name, arg.Type.ToString());
             }
         }
 

--- a/src/Lua/LuaValue.cs
+++ b/src/Lua/LuaValue.cs
@@ -48,12 +48,14 @@ public readonly struct LuaValue : IEquatable<LuaValue>
                 }
                 else if (t == typeof(int))
                 {
+                    if (!MathEx.IsInteger(value)) break;
                     var v = (int)value;
                     result = Unsafe.As<int, T>(ref v);
                     return true;
                 }
                 else if (t == typeof(long))
                 {
+                    if (!MathEx.IsInteger(value)) break;
                     var v = (long)value;
                     result = Unsafe.As<long, T>(ref v);
                     return true;
@@ -144,8 +146,8 @@ public readonly struct LuaValue : IEquatable<LuaValue>
                         result = tValue;
                         return true;
                     }
-                    result = default!;
-                    return false;
+
+                    break;
                 }
                 else if (t == typeof(object))
                 {

--- a/src/Lua/Standard/BasicLibrary.cs
+++ b/src/Lua/Standard/BasicLibrary.cs
@@ -365,15 +365,8 @@ public sealed class BasicLibrary
     {
         var arg0 = context.GetArgument(0);
 
-        if (arg0.TryRead<double>(out var d))
+        if (arg0.TryRead<int>(out var index))
         {
-            if (!MathEx.IsInteger(d))
-            {
-                throw new LuaRuntimeException(context.State.GetTraceback(), "bad argument #1 to 'select' (number has no integer representation)");
-            }
-
-            var index = (int)d;
-
             if (Math.Abs(index) > context.ArgumentCount)
             {
                 throw new LuaRuntimeException(context.State.GetTraceback(), "bad argument #1 to 'select' (index out of range)");

--- a/src/Lua/Standard/FileHandle.cs
+++ b/src/Lua/Standard/FileHandle.cs
@@ -201,17 +201,12 @@ public class FileHandle : ILuaUserData
             ? context.GetArgument<string>(1)
             : "cur";
         var offset = context.HasArgument(2)
-            ? context.GetArgument<double>(2)
+            ? context.GetArgument<int>(2)
             : 0;
 
         if (whence is not ("set" or "cur" or "end"))
         {
             throw new LuaRuntimeException(context.State.GetTraceback(), $"bad argument #2 to 'seek' (invalid option '{whence}')");
-        }
-
-        if (!MathEx.IsInteger(offset))
-        {
-            throw new LuaRuntimeException(context.State.GetTraceback(), $"bad argument #3 to 'seek' (number has no integer representation)");
         }
 
         try
@@ -233,15 +228,10 @@ public class FileHandle : ILuaUserData
         var file = context.GetArgument<FileHandle>(0);
         var mode = context.GetArgument<string>(1);
         var size = context.HasArgument(2)
-            ? context.GetArgument<double>(2)
+            ? context.GetArgument<int>(2)
             : -1;
 
-        if (!MathEx.IsInteger(size))
-        {
-            throw new LuaRuntimeException(context.State.GetTraceback(), $"bad argument #3 to 'setvbuf' (number has no integer representation)");
-        }
-
-        file.SetVBuf(mode, (int)size);
+        file.SetVBuf(mode, size);
 
         buffer.Span[0] = true;
         return new(1);

--- a/src/Lua/Standard/Internal/IOHelper.cs
+++ b/src/Lua/Standard/Internal/IOHelper.cs
@@ -117,14 +117,8 @@ internal static class IOHelper
                             break;
                     }
                 }
-                else if (format.TryRead<double>(out var d))
+                else if (format.TryRead<int>(out var count))
                 {
-                    if (!MathEx.IsInteger(d))
-                    {
-                        throw new LuaRuntimeException(state.GetTraceback(), $"bad argument #{i + startArgumentIndex} to 'read' (number has no integer representation)");
-                    }
-
-                    var count = (int)d;
                     using var byteBuffer = new PooledArray<byte>(count);
 
                     for (int j = 0; j < count; j++)

--- a/src/Lua/Standard/OperatingSystemLibrary.cs
+++ b/src/Lua/Standard/OperatingSystemLibrary.cs
@@ -119,14 +119,9 @@ public sealed class OperatingSystemLibrary
             {
                 Environment.Exit(b ? 0 : 1);
             }
-            else if (code.TryRead<double>(out var d))
+            else if (code.TryRead<int>(out var d))
             {
-                if (!MathEx.IsInteger(d))
-                {
-                    throw new LuaRuntimeException(context.State.GetTraceback(), $"bad argument #1 to 'exit' (number has no integer representation)");
-                }
-
-                Environment.Exit((int)d);
+                Environment.Exit(d);
             }
             else
             {


### PR DESCRIPTION
Related to #70, fixes an issue where `TryRead<int>()` could read a value even if it wasn't an integer. Also fixes the error message when trying to read a non-integer number argument with `GetArgument<int>()`.