### PR TITLE
Ensure array capacity only if index is larger than array length with table.insert function

### DIFF
--- a/src/Lua/LuaTable.cs
+++ b/src/Lua/LuaTable.cs
@@ -149,8 +149,8 @@ public sealed class LuaTable
         }
 
         var arrayIndex = index - 1;
-        
-        if (index > array.Length)
+
+        if (index > array.Length || array[^1].Type != LuaValueType.Nil)
         {
             EnsureArrayCapacity(array.Length + 1);
         }

--- a/src/Lua/LuaTable.cs
+++ b/src/Lua/LuaTable.cs
@@ -149,7 +149,11 @@ public sealed class LuaTable
         }
 
         var arrayIndex = index - 1;
-        EnsureArrayCapacity(array.Length + 1);
+        
+        if (index > array.Length)
+        {
+            EnsureArrayCapacity(array.Length + 1);
+        }
 
         if (arrayIndex != array.Length - 1)
         {


### PR DESCRIPTION
Fixes #78 
Fixes #79 

Tested with #78 case and small table.insert tests - memory consumption is no longer that big